### PR TITLE
fix(ente-photos): use URL-safe base64 for jwt secret

### DIFF
--- a/charts/ente-photos/templates/museum/secret.yaml
+++ b/charts/ente-photos/templates/museum/secret.yaml
@@ -83,14 +83,15 @@ stringData:
       {{- end }}
 
     # JWT Configuration
-    # IMPORTANT: Ente requires standard base64-encoded secret (NOT hex, NOT URL-safe!)
-    # jwt.secret: 32 random bytes, standard base64
+    # IMPORTANT: Ente requires URL-safe base64-encoded secret (NOT hex, NOT standard base64!)
+    # Reference: https://github.com/ente-io/ente/blob/d67b3066d70502b5781c8945640cfc4c5b322f0b/server/cmd/museum/main.go#L128-L131
+    # jwt.secret: 32 random bytes, URL-safe base64
     jwt:
       {{- if .Values.credentials.jwt.secret }}
       secret: {{ .Values.credentials.jwt.secret | quote }}
       {{- else }}
-      # Auto-generated: 32 random bytes, standard base64 (randBytes already outputs base64)
-      secret: {{ randBytes 32 | quote }}
+      # Auto-generated: 32 random bytes, URL-safe base64
+      secret: {{ randBytes 32 | replace "/" "_" | replace "+" "-" | quote }}
       {{- end }}
 
     {{- with .Values.credentials.smtp }}

--- a/charts/ente-photos/values.schema.json
+++ b/charts/ente-photos/values.schema.json
@@ -260,7 +260,7 @@
           "properties": {
             "secret": {
               "type": "string",
-              "description": "JWT signing secret (32 random bytes, standard base64, auto-generated if empty)"
+              "description": "JWT signing secret (32 random bytes, URL-safe base64, auto-generated if empty)"
             }
           }
         },

--- a/charts/ente-photos/values.yaml
+++ b/charts/ente-photos/values.yaml
@@ -360,10 +360,11 @@ credentials:
     hash: ""
 
   # JWT configuration
-  # IMPORTANT: Secret must be standard base64-encoded (NOT hex, NOT URL-safe!)
-  # Generate with: openssl rand 32 | base64
+  # IMPORTANT: Secret must be URL-safe base64-encoded (NOT hex, NOT standard base64!)
+  # Reference: https://github.com/ente-io/ente/blob/d67b3066d70502b5781c8945640cfc4c5b322f0b/server/cmd/museum/main.go#L128-L131
+  # Generate with: openssl rand 32 | base64 | tr '/+' '_-'
   jwt:
-    # -- JWT signing secret (32 random bytes, standard base64, auto-generated if empty)
+    # -- JWT signing secret (32 random bytes, URL-safe base64, auto-generated if empty)
     # Example: "Pdl5M1YDf8foxryxuHVHk83YhDSWpJvk9P97rY3dJkE="
     secret: ""
 


### PR DESCRIPTION
Update ente-photos JWT secret docs and generation to match Ente's actual decoding logic, which uses b64.URLEncoding.DecodeString().

- document jwt.secret as URL-safe base64
- generate auto-created JWT secrets with URL-safe alphabet
- add upstream code reference in chart comments
- update values schema description