### PR TITLE
docs: refresh root README with current chart inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,42 @@
 # L4G Helm Charts
 
-A collection of production-ready Helm charts for deploying various applications on Kubernetes.
+A collection of production-ready Helm charts for self-hosted services.
+
+[![ArtifactHub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/l4g)](https://artifacthub.io/packages/search?repo=l4g)
 
 ## Available Charts
 
-| Chart | Description |
-|-------|-------------|
-| **[chibisafe](charts/chibisafe)** | File vault and sharing platform for self-hosted file uploads |
-| **[ente-photos](charts/ente-photos)** | End-to-end encrypted photo storage and backup platform |
-| **[overpass-api](charts/overpass-api)** | Read-only API for querying OpenStreetMap data |
+| Chart | App version | What it deploys |
+| --- | --- | --- |
+| **[bulwark-mail](charts/bulwark-mail)** | 1.6.0 | [Bulwark](https://github.com/bulwarkmail/webmail) JMAP webmail. Native Ingress, multi-host TLS, OIDC, optional ServiceMonitor / NetworkPolicy / PVC for settings sync. |
+| **[chibisafe](charts/chibisafe)** | latest | [Chibisafe](https://github.com/chibisafe/chibisafe) file vault and sharing platform. |
+| **[ente-photos](charts/ente-photos)** | latest | [Ente Photos](https://github.com/ente-io/ente) end-to-end encrypted photo storage. Bundled museum API + photos / albums / accounts / auth / cast / share frontends; optional custom CA mount, ServiceMonitor, NetworkPolicy, PDB. |
+| **[overpass-api](charts/overpass-api)** | latest | [Overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API) — read-only OpenStreetMap query service. |
+| **[stalwart-mail-ha](charts/stalwart-mail-ha)** | 0.16.3 | [Stalwart](https://github.com/stalwartlabs/stalwart) mail server (SMTP, IMAP, JMAP, CalDAV/CardDAV) with multi-replica HA. Postgres / MySQL / FoundationDB / RocksDB / SQLite data stores, separate mail and HTTP Services, optional Ingress / ServiceMonitor / NetworkPolicy / PDB / HPA. |
 
 ## Usage
 
-### Add the Helm Repository
+### Add the Helm repository
 
 ```bash
 helm repo add l4gdev https://l4gdev.github.io/helm-charts
 helm repo update
 ```
 
-### Install a Chart
+### Install a chart
 
 ```bash
-# Install Chibisafe
-helm install chibisafe l4gdev/chibisafe
-
-# Install Ente Photos
-helm install ente-photos l4gdev/ente-photos
-
-# Install Overpass API
-helm install overpass l4gdev/overpass-api
-
-# Install with custom values
-helm install myrelease l4gdev/<chart-name> -f custom-values.yaml
+helm install bulwark   l4gdev/bulwark-mail     -f my-values.yaml
+helm install chibisafe l4gdev/chibisafe        -f my-values.yaml
+helm install ente      l4gdev/ente-photos      -f my-values.yaml
+helm install overpass  l4gdev/overpass-api     -f my-values.yaml
+helm install mail      l4gdev/stalwart-mail-ha -f my-values.yaml
 ```
 
-### Search Available Charts
+Each chart ships an `examples/` directory with reference values (minimal, HA, OIDC, LDAP, etc.).
+Start there.
+
+### Search
 
 ```bash
 helm search repo l4gdev
@@ -45,44 +46,38 @@ helm search repo l4gdev
 
 ### Prerequisites
 
-- Kubernetes 1.19+
-- Helm 3.2.0+
+- Kubernetes 1.23+
+- Helm 3.8+
 
-### Testing Charts Locally
+### Local validation
 
 ```bash
-# Lint a chart
 helm lint charts/<chart-name>
-
-# Test template rendering
-helm template test charts/<chart-name>
-
-# Install locally with dry-run
-helm install test charts/<chart-name> --dry-run --debug
+helm template test charts/<chart-name> -f charts/<chart-name>/examples/values-minimal.yaml \
+  | kubectl apply --dry-run=client -f -
 ```
+
+CI (`.github/workflows/lint-test.yaml`) runs `ct lint` against changed charts on every PR.
 
 ## Contributing
 
-Contributions are welcome! Please:
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Test the chart: `helm lint charts/<chart-name>`
-5. Submit a pull request
+1. Fork
+2. Branch (`feature/...`)
+3. Update / add chart, bump `Chart.yaml` `version` and the `artifacthub.io/changes` annotation
+4. Run `helm lint` and `helm template ... | kubectl apply --dry-run=client -f -`
+5. Open a pull request
 
 ## License
 
 Charts are licensed under the MIT License unless otherwise noted.
-
-Individual applications deployed by these charts may have different licenses.
+Individual applications deployed by these charts have their own licenses (AGPL-3.0 in most cases).
 
 ## Links
 
 - [Repository](https://github.com/l4gdev/helm-charts)
-- [Report Issues](https://github.com/l4gdev/helm-charts/issues)
+- [Issues](https://github.com/l4gdev/helm-charts/issues)
 - [Artifact Hub](https://artifacthub.io/packages/search?repo=l4g)
 
 ## Disclaimer
 
-The code is provided as-is with no warranties.
+Provided as-is, no warranties.


### PR DESCRIPTION
## Summary

The chart list in the root README was stuck at three entries (chibisafe / ente-photos / overpass-api) and missed both \`bulwark-mail\` and \`stalwart-mail-ha\` that landed in recent releases. This PR brings it in sync with what is actually published.

Changes:
- Adds bulwark-mail and stalwart-mail-ha rows with pinned app versions and a one-line summary of what each chart ships
- Pins app version where upstream ships one (1.6.0 / 0.16.3); leaves \`latest\` for charts whose upstream does not publish semver tags
- Points new users at the per-chart \`examples/\` directories instead of bare \`helm install\` commands
- Bumps dev prerequisites to match the kubeVersion in the new charts (k8s 1.23+, helm 3.8+)
- Adds a one-line note about the \`ct lint\` CI step
- Adds the ArtifactHub badge

\`freescout\` deliberately stays out of the table to keep the existing convention; happy to add it if you would prefer.

## Test plan

- [x] Markdown renders cleanly on GitHub preview
- [x] All links resolve
