### PR TITLE
fix(ente-photos) : webfronted default ports in NetworkPolicy

### DIFF
--- a/charts/ente-photos/Chart.yaml
+++ b/charts/ente-photos/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
   - name: L4G
     email: contact@l4g.dev
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "latest"
 
 annotations:
@@ -37,6 +37,8 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
+    - kind: fixed
+      description: Fix webfronted default ports in NetworkPolicy
     - kind: added
       description: New web.albums component (port 3002) so public album sharing works (#2)
     - kind: added

--- a/charts/ente-photos/templates/networkpolicy.yaml
+++ b/charts/ente-photos/templates/networkpolicy.yaml
@@ -43,7 +43,7 @@ spec:
           podSelector: {}
       ports:
         - protocol: TCP
-          port: {{ .Values.web.auth.containerPort | default 3000 }}
+          port: {{ .Values.web.auth.containerPort | default 3003 }}
     {{- end }}
     {{- if .Values.web.accounts.enabled }}
     - from:
@@ -51,7 +51,7 @@ spec:
           podSelector: {}
       ports:
         - protocol: TCP
-          port: {{ .Values.web.accounts.containerPort | default 3000 }}
+          port: {{ .Values.web.accounts.containerPort | default 3001 }}
     {{- end }}
     {{- if .Values.web.cast.enabled }}
     - from:
@@ -59,7 +59,7 @@ spec:
           podSelector: {}
       ports:
         - protocol: TCP
-          port: {{ .Values.web.cast.containerPort | default 3000 }}
+          port: {{ .Values.web.cast.containerPort | default 3004 }}
     {{- end }}
     {{- if .Values.web.share.enabled }}
     - from:
@@ -67,7 +67,15 @@ spec:
           podSelector: {}
       ports:
         - protocol: TCP
-          port: {{ .Values.web.share.containerPort | default 3000 }}
+          port: {{ .Values.web.share.containerPort | default 3005 }}
+    {{- end }}
+    {{- if .Values.web.albums.enabled }}
+    - from:
+        - namespaceSelector: {}
+          podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.web.share.containerPort | default 3002 }}
     {{- end }}
     {{- with .Values.networkPolicy.additionalIngressRules }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Update the ports in networkPolicy as per https://github.com/ente-io/ente/blob/664baccfd2b08cd027c1c53e6ea1e7ed1ee387c3/web/docs/docker.md?plain=1#L8